### PR TITLE
Finishes #160928240 Merge Delete Feature into Develop

### DIFF
--- a/api/v2/database.py
+++ b/api/v2/database.py
@@ -109,7 +109,7 @@ def connect_to_and_query_db(query=None, db_url=None):
     return conn, cursor
 
 
-def insert_into_db(query):
+def query_db_no_return(query):
     """
         Handles INSERT queries
     """

--- a/api/v2/models.py
+++ b/api/v2/models.py
@@ -31,7 +31,7 @@ class User:
             '{}', '{}', '{}'
         )""".format(self.username, self.email, self.password)
 
-        database.insert_into_db(query)
+        database.query_db_no_return(query)
 
     @staticmethod
     def retrieve_user_from_db(email):
@@ -95,7 +95,7 @@ class Order:
                 self.quantity,
                 self.total_order_cost)
 
-        database.insert_into_db(query)
+        database.query_db_no_return(query)
 
     def retrieve_order_from_db(self, food_item_name):
         """
@@ -130,7 +130,7 @@ class FoodItem:
                 self.food_item_name,
                 self.food_item_price)
 
-        database.insert_into_db(query)
+        database.query_db_no_return(query)
 
     def retrieve_food_item_from_db(self, food_item_name):
         """

--- a/api/v2/resources/admin_only_routes.py
+++ b/api/v2/resources/admin_only_routes.py
@@ -151,9 +151,10 @@ class Order(Resource):
         # if user_role and order data confirmed ok
 
         if order_id:
-         # see if order exists
+            # see if order exists
             search_query = """
-            SELECT * FROM orders WHERE orders.order_id = '{}'""".format(order_id)
+            SELECT * FROM orders
+            WHERE orders.order_id = '{}'""".format(order_id)
 
             order = database.select_from_db(search_query)
             if not order:

--- a/api/v2/resources/admin_only_routes.py
+++ b/api/v2/resources/admin_only_routes.py
@@ -120,16 +120,14 @@ class Order(Resource):
         order = database.select_from_db(query)
 
         if not order:
-            abort(make_response(jsonify(
-                message="Order with id '{}' not found.".format(
-                    order_id)), 404))
+            validate.abort_order_not_found(order_id)
 
         update_query = """
         UPDATE orders
         SET order_status = '{}' WHERE
         orders.order_id = '{}'""".format(order_status, order_id)
 
-        database.insert_into_db(update_query)
+        database.query_db_no_return(update_query)
 
         updated_order = database.select_from_db(query)
 
@@ -139,5 +137,58 @@ class Order(Resource):
             "message": "Order found.",
             "order": formatted_updated_order
         }), 200)
+
+        return response
+
+    @jwt_required
+    def delete(self, order_id=None):
+        """
+            DELETE /orders/order_id and
+            DELETE /orders endpoint
+            : can only delete where status is 'Complete' or 'Cancelled'
+        """
+        validate.abort_if_user_role_not_appropriate("admin")
+        # if user_role and order data confirmed ok
+
+        if order_id:
+         # see if order exists
+            search_query = """
+            SELECT * FROM orders WHERE orders.order_id = '{}'""".format(order_id)
+
+            order = database.select_from_db(search_query)
+            if not order:
+                validate.abort_order_not_found(order_id)
+
+            if order[0][3] not in ["Complete", "Cancelled"]:
+                abort(make_response(jsonify(
+                    message="Not deleted. Status is '{}'. \
+Status must be 'Cancelled' or 'Complete' to delete".format(order[0][3])
+                ), 401))
+
+            # if order_status is 'Cancelled' or 'Complete'
+            delete_single_order = """
+            DELETE FROM orders
+            WHERE orders.order_id = '{}'
+            AND orders.order_status = 'Cancelled'
+            OR orders.order_status = 'Complete' """.format(order_id)
+
+            database.query_db_no_return(delete_single_order)
+
+            # Confirm deletion by querying db for same item
+            order = database.select_from_db(search_query)
+            if order:
+                # Means the deletion did not happen
+                abort(make_response(jsonify(
+                    message="Error. Not deleted for some reason"
+                ), 500))
+        else:
+            delete_all_orders = """
+            DELETE FROM orders WHERE orders.order_status = 'Complete'
+            OR orders.order_status = 'Cancelled'"""
+
+            database.query_db_no_return(delete_all_orders)
+
+        response = make_response(jsonify(
+            message="Delete successful."), 200)
 
         return response

--- a/run.py
+++ b/run.py
@@ -54,7 +54,8 @@ API.add_resource(ShoppingCart, '{}/users/orders'.format(BASE_URL))
 API.add_resource(Menu, '{}/menu'.format(BASE_URL))
 API.add_resource(AdminLogin, '{}/login'.format(BASE_URL))
 API.add_resource(AllOrders, '{}/orders'.format(BASE_URL))
-API.add_resource(Order, '{}/orders/<int:order_id>'.format(BASE_URL))
+API.add_resource(Order, '{}/orders/<int:order_id>'.format(
+    BASE_URL), '{}/orders'.format(BASE_URL))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### What does this PR do?
This PR merges the `DELETE /orders` and `DELETE /orders/<int:order_id>` endpoints into the `develop` branch, from where `Challenge 3` is being built.
With this feature, an order (or orders) for which the order status is "`Cancelled`" or "`Complete`" can be removed from the DB.

#### How should this be manually tested?
1. After cloning the repo, `git checkout ft-api-v2-delete-order-160928240`

2. Create and activate a [Virtual Environment](https://virtualenv.pypa.io/en/stable/).

3. Run `pip install -r requirements.txt` to install dependencies

4. To test locally: 
* Run `export FLASK_APP=run.py`
* Run `flask run` to start the server
* Send `DELETE` requests to `localhost:5000/api/v2/orders` to delete multiple orders, or to `localhost:5000/api/v2/orders/<int:order_id>`  to delete a specific order.

#### What are the relevant pivotal tracker stories?
[#160928240](https://www.pivotaltracker.com/story/show/160928240)

